### PR TITLE
build: fixes GitHub Dependabot run error

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,3 +1,4 @@
+# Conditional for GitHub Dependabot
 if File.exists?("blend/premix.exs") do
   Code.compile_file("blend/premix.exs")
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,4 +1,6 @@
-Code.compile_file("blend/premix.exs")
+if File.exists?("blend/premix.exs") do
+  Code.compile_file("blend/premix.exs")
+end
 
 defmodule SlackRequest.MixProject do
   use Mix.Project


### PR DESCRIPTION
Dependabot fails with:

(Code.LoadError) could not load dependabot_tmp_dir/blend/premix.exs. Reason: enoent

when evaluating mix.exs to check for dependency updates.

I guess what dependabot does is just copy the `mix.exs` to a tmp dir and work there. Of course `premix.exs` won't be there and we have no control over that.

![image](https://github.com/mimiquate/slack_request/assets/456459/923afd4d-885d-4490-bb22-01434ff544df)
